### PR TITLE
Riemann memory warnings bad calculation

### DIFF
--- a/bin/riemann-health
+++ b/bin/riemann-health
@@ -132,16 +132,15 @@ class Riemann::Tools::Health
   end
 
   def linux_memory
-    m = File.read('/proc/meminfo').split(/\n/).inject({}) { |info, line|
-      x = line.split(/:?\s+/)
-      # Assume kB...
-      info[x[0]] = x[1].to_i
-      info
-    }
+    processes = `ps -eo pmem,pid,comm | grep -v 0.0 | grep -v %MEM | sort -nrb -k1`
 
-    free = m['MemFree'].to_i + m['Buffers'].to_i + m['Cached'].to_i
-    total = m['MemTotal'].to_i
-    fraction = 1 - (free.to_f / total)
+    total = 0.0
+    processes.each_line do |process_line|
+      info = process_line.split(' ')
+      total += info[0].to_f
+    end
+
+    fraction = (total/100).round(2)
 
     report_pct :memory, fraction, "used\n\n#{`ps -eo pmem,pid,comm | sort -nrb -k1 | head -10`.chomp}"
   end


### PR DESCRIPTION
> 91.01% used
> 
> 18.9  1633 java
> 2.6  1052 ruby
> 0.4  1687 ruby
> 0.4  1675 ruby
> 0.2  1114 rsyslogd
> 0.1 10700 bosh-agent
> 0.1  1718 nxlog
> 0.1  1651 zk-backyp
> %MEM   PID COMMAND
> 0.0 57814 head

As this log shows, there was bigger usage but now its about 21% (sum of processes). Linux does not free its memory always after stopping usage.
Thats why the overall usage is 91% (which is ok for linux). 
So this notification should not appear.
One of solutions to this, is to notify memory problems when sum of processed is bigger than 90%, not overall memory usage of system.
